### PR TITLE
making uci command parsing cleaner, and starting on go command

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -13,8 +13,7 @@ menu(){
     echo "    1. Play against engine"
     echo "    2. Play against friend"
     echo "    3. Engine vs Engine"
-    echo "    4. Run Perft" 
-    echo "    5. UCI test (Under Development)" 
+    echo "    4. UCI test (Under Development)" 
 
     read -p "    >> " choice
 }
@@ -31,17 +30,16 @@ echo -e "=====================================\n"
 menu
 
 case $choice in
-    1) 
+    1)  
+        ask_fen
         $executable -f "$fen" -m "pve";;
+        
     2)  ask_fen
         $executable -f "$fen" -m "pvp" ;;
     3) 
         ask_fen 
         $executable -f "$fen" -m "eve" ;;
     4) 
-        ask_fen
-        $executable -f "$fen" -m "perft" ;;
-    5) 
         $executable -f "$fen" -m "uci" ;;
     *) 
         exit ;;  

--- a/src/defs.cpp
+++ b/src/defs.cpp
@@ -148,36 +148,6 @@ std::vector<std::string> splitString(const std::string& input, const char& delim
     return parts;
 }
 
-std::string get_first(const std::string& input, const char& delimiter) {
-    std::istringstream iss(input);
-    std::string part;
-    
-    while (std::getline(iss, part, delimiter)) {
-        return part;
-    }
-
-    return "";
-}
-
-/// @brief Get substring up to a certain character or newline
-/// @param input 
-/// @param substr 
-/// @param other_word 
-/// @param from 
-/// @return True if successful, False if not
-bool get_next_uci_param(const std::string& input, std::string& substr, std::string other_word, size_t from){
-    std::string::size_type pos = input.find(other_word[0]);
-
-    if(pos == std::string::npos){
-        substr = input.substr(from, pos-from);
-        return (from != input.size());
-    } else {
-        assert(from <= pos);
-        substr = input.substr(from, pos-from);
-        return !input.compare(pos, other_word.size(), other_word);
-    }
-}
-
 std::string removeWhiteSpace(std::string str){
     std::regex pattern(R"(^\s+|\s+$|\t|\n)");
 
@@ -271,6 +241,8 @@ uint convert_square_to_index(uint square, int colour_index){
     return 4*y + std::min(7-x, x);
 }
 
+// This way of initialising the PV tables was layed out in Bluefever Software's video: https://www.youtube.com/watch?v=AlwyJFG466M
+
 /// @brief Dynamically allocate number of entries for the PV table based on the size in bytes required
 /// @param table 
 /// @param PV_size 
@@ -297,4 +269,24 @@ void clear_pv_table(PV_Table* table){
     }
 
     if(debug){std::cout << "info string cleared PV table " << std::endl;}
+}
+
+std::vector<std::string> get_tokens(std::string& input, std::regex pattern){
+    std::vector<std::string> tokens;
+
+    std::sregex_iterator iter(input.begin(), input.end(), pattern);
+    std::sregex_iterator end;
+
+    while (iter != end) {
+        tokens.push_back(iter->str());
+        ++iter;
+    }
+
+    return tokens;
+}
+
+bool is_valid_num(const std::string& numString){
+    auto pattern = std::regex(R"([0-9]+)");
+
+    return std::regex_match(numString, pattern);
 }

--- a/src/defs.h
+++ b/src/defs.h
@@ -1,10 +1,6 @@
 #ifndef DEFS_H
 #define DEFS_H
 
-#define STARTING_FEN "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
-#define MOVE_FORMAT std::regex(R"([a-h][1-8][a-h][1-8](q|r|n|b)?)")
-#define VERSION_FORMAT std::regex(R"(v[0-2])")
-
 #include <cstdint>
 #include <iostream>
 #include <filesystem>
@@ -17,6 +13,11 @@
 
 typedef uint64_t U64;
 typedef unsigned int uint;
+
+#define STARTING_FEN "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+#define MOVE_FORMAT std::regex(R"([a-h][1-8][a-h][1-8](q|r|n|b)?)")
+#define VERSION_FORMAT std::regex(R"(v[0-2])")
+#define UCI_COMMAND_FORMAT std::regex(R"(([A-Za-z1-8]+/?){8} [wb] ([KQkq]+|-) ([a-f1-8]+|-) [0-9]+ [1-9]+|[a-z0-9]+|[a-z]+|[0-9]+)")
 
 #define CAPTURE_FLAG 0x4000
 #define PROMO_FLAG 0x8000
@@ -88,7 +89,7 @@ typedef enum{
     BLACK = -1,
 } colour;
 
-typedef enum{PVE, EVE, PVP, PERFT, UCI} game_modes;
+typedef enum{PVE, EVE, PVP, UCI} game_modes;
  
 typedef enum{north, east, west, south, noEa, soEa, noWe, soWe} dirs;
 
@@ -161,5 +162,9 @@ int convert_piece_to_index(int piece);
 int convert_piece_to_zobrist_index(int piece);
 
 uint convert_square_to_index(uint square, int colour_index);
+
+std::vector<std::string> get_tokens(std::string& input, std::regex pattern);
+
+bool is_valid_num(const std::string& numString);
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,9 +23,8 @@ int main(int argc, char* argv[]){
                     mode = EVE;
                 } else if(strcmp(optarg,"uci") == 0){
                     mode = UCI;
-                } else {
-                    mode = PERFT;
                 }
+                
                 break;
             default:
                 break;

--- a/src/run.cpp
+++ b/src/run.cpp
@@ -4,33 +4,35 @@ Run::Run(std::string& fen, game_modes mode) : mode(mode) {
     if(mode == PVP){
         board.init_from_fen(fen);  
         movegen.set_state(&board);
-        movegen.generate_moves();    
+        movegen.generate_moves();   
+
         run_PVP();
+
     } else if(mode == PVE){
         board.init_from_fen(fen);  
         // init pv table, pass size in bytes for the table
         init_pv_table(&board.pv_table, 0x400000);
         movegen.set_state(&board);    
         movegen.generate_moves();   
+
         int depth = get_perft_depth();
         set_engine(depth);
         run_PVE();
+
     } else if(mode == EVE) {
         board.init_from_fen(fen);  
         // init pv table, pass size in bytes for the table
         init_pv_table(&board.pv_table, 0x400000);
         movegen.set_state(&board); 
         movegen.generate_moves();      
+
         int depth = get_perft_depth();
         set_engine(depth);
         run_EVE();
+
     } else if(mode == UCI){
         run_PVE_UCI();
-    } else if(mode == PERFT){
-        board.init_from_fen(fen);  
-        movegen.set_state(&board);   
-        movegen.generate_moves();   
-        run_perft();
+        
     } else {
         std::cerr << "Unexpected mode " << mode << std::endl;
     }
@@ -92,58 +94,6 @@ bool Run::end_game(){
     } else {return !run;} 
 
     return true;
-}
-
-void Run::run_perft(){
-    board.view_board();
-    std::vector<Move> moves = movegen.generate_moves();
-
-    while(!end_game()){
-        int depth = get_perft_depth();
-        perftDriver(depth, moves);
-    }
-}
-
-void Run::perftDriver(int& depth, const std::vector<Move>& moves){
-    int num_pos = 0, total_pos = 0;
-    auto start = high_resolution_clock::now();
-
-    for(auto move : moves){
-        board.make_move(move);
-        num_pos = movegenTest(depth-1);
-        board.undo_move();
-
-        std::cout << move << " " << std::dec << num_pos << std::endl;
-        total_pos += num_pos;
-    }
-
-    auto end = high_resolution_clock::now();
-
-    auto duration = duration_cast<milliseconds>(end-start);
-
-    std::cout << "nodes " << std::to_string(total_pos) << std::endl;
-
-    std::cout << "time taken " << std::to_string(duration.count()) << " ms" << std::endl;
-    std::cout << "nodes per second " << std::to_string(trunc(total_pos / (duration.count() / 1000.0))) << " nodes/sec" << std::endl;
-    std::cout << "\n";
-}
-
-int Run::movegenTest(int depth){
-    std::vector<Move> moves = movegen.generate_moves();
-    
-    if(depth == 0){
-        return 1;
-    }
-
-    int num_nodes = 0;    
-
-    for(auto move : moves){
-        board.make_move(move);
-        num_nodes += movegenTest(depth-1);                               
-        board.undo_move();
-    }
-
-    return num_nodes;
 }
 
 std::string Run::get_colour_choice(){

--- a/src/run.h
+++ b/src/run.h
@@ -25,12 +25,6 @@ class Run{
 
         bool end_game();
 
-        void run_perft();
-
-        void perftDriver(int& depth, const std::vector<Move>& moves);
-
-        int movegenTest(int depth);
-
         void get_input_from_player();
 
         std::string get_colour_choice();

--- a/src/uci.h
+++ b/src/uci.h
@@ -8,25 +8,52 @@
 
 int convert_to_move(const std::tuple<std::string, std::string, std::string>& str_move, MoveGen* movegen, Move& move);
 std::tuple<std::string, std::string, std::string> parse_player_move(std::string& str_move);
+bool is_valid_go_param(std::string token);
 
 class Uci{
     public:
         Uci(Board* _board, MoveGen* _movegen) : board(_board), movegen(_movegen) {}
         void uci_communication();
+
+        std::string current_token(){
+            if(pointer < tokens.size()){
+                return tokens[pointer];
+            } else {
+                return "";
+            }
+        }
+
+        std::string previous_token(){
+            assert((0 < pointer) && (pointer < tokens.size()));
+            return tokens[pointer-1];
+        }
+
+        void perft_driver(int& depth);
+
+        int movegen_test(int depth);
+
+        bool out_of_tokens(){return pointer == tokens.size()-1;}
         void process_uci();
         void process_position();
         void process_isready();
         void process_debug();
+        void process_go();
 
     private:
         std::string input;
         size_t pointer = 0;
+        std::vector<std::string> tokens;
         Board* board;
         MoveGen* movegen;
 
         size_t input_size = 0;
+        std::vector<Move> moves_to_search;
+        std::string token_s_arg;
+        int token_i_arg;
+        Move _move;
 
         bool run = true;
+        bool searchpos_got = false, position_got = false;
 };
 
 #endif


### PR DESCRIPTION
- Uci commands are now tokenised which makes parsing them easier and cleaner
- Perft functionality completely moved over to UCI `go` command control. I copied Stockfish's semantics so: `go perft 1` runs perft test to a depth of 1. 
